### PR TITLE
Contain runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 ideas.gdoc
 node_modules
 npm-debug.log
+generated

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ gulp.task('default', jasmine({
 
 ## Using with webserving
 
+When serving, the generated spec runner is not added to the plugin folder, resulting in a cleaner project (no need to `gitignore` `SpecRunner.html`).
+
 ```javascript
 var gulp    = require('gulp'),
     jasmine = require('gulp-jasmine-livereload-task');
@@ -95,7 +97,7 @@ livereload          Livereload server port. Default: 35729
 host                Host name. If need to be served
 port                Port number. If need to be served
 staticAssetsPath    The root path of the static files served by the webserver, by default it is the plugin folder
-specRunner          The path of the SpecRunner.html file, by default it is the plugin folder / SpecRunner.html
+specRunner          The path to a SpecRunner.html file (relative to staticAssetsPath), if you wish to use your own runner file when serving instead of using the generated runner. This file will be used as-is, not modified by gulp-jasmine-livereload-task.
 jshint.files        Files to be checked by jshint
 jshint.options      Options used by jshint
 jshint.version      Embedded Jshint version. Default: 2.6. Embedded versions: 2.6

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ var parentRequire = require('parent-require'),
         'peer': path.resolve(__dirname, 'vendor/jasmine-peer/SpecRunner.html')
     },
     jshint = {
-        '2.6': path.resolve(__dirname, 'jshint-2.6.0/jshint.js')
+        '2.6': path.resolve(__dirname, 'vendor/jshint-2.6.0/jshint.js')
     },
     defaults = {
         files: undefined,

--- a/index.js
+++ b/index.js
@@ -26,7 +26,6 @@ var parentRequire = require('parent-require'),
         jasmine: '2.2',
         livereload: '35729',
         staticAssetsPath: '.',
-        specRunner: 'SpecRunner.html',
         jshint: {
             version: '2.6',
             files: [],
@@ -71,8 +70,18 @@ module.exports = function (opts) {
 };
 
 function createSpecrunner() {
-    var target = gulp.dest('.'),
-        specrunner;
+    var specrunner;
+
+    var target = options.host ?
+        gulp.dest('.', {cwd: path.join(__dirname, 'generated')}) :
+        gulp.dest('.');
+
+    var specRunnerPath = options.specRunner || path.join(
+        'node_modules',
+        'gulp-jasmine-livereload-task',
+        'generated',
+        'SpecRunner.html'
+    );
 
     target.on('end', function () {
         if (!opened) {
@@ -82,9 +91,10 @@ function createSpecrunner() {
                 gulp.src(options.staticAssetsPath)
                     .pipe(
                         webserver({
-                            open: options.specRunner,
+                            open: true,
                             host: options.host,
-                            port: options.port
+                            port: options.port,
+                            fallback: specRunnerPath
                         })
                     );
             }


### PR DESCRIPTION
Closes #11.

Note this introduces potentially **breaking changes** and should therefore should have a major version bump. Specifically, the behavior of the `specRunner` option is slightly different.

* When `host` is used, the runner file is *not* placed in the user's project folder. Instead, it is placed inside of a generated folder inside this package. This is more polite to the user, as they do not have to edit their `gitignore` to ignore the runner file.
* The server now falls back to the generated file, so the root `/` path can be used — matching the output in the command line (`serving on http://localhost:8000`, for example). This is a **breaking change**.
* This also fixes a bug with the embedded JSHint vendor path. Not sure where or how that bug got introduced as I could have sworn the tests passed before, but worth mentioning.
* The `specRunner` option now behaves slightly differently. When included, it overrides the generated runner file. When omitted, the generated runner will be used. **However**, an included runner by the name `SpecRunner.html` in the static assets directory will **not** be used by default — this is a **breaking change**. The user has to either explicitly opt in to using their own runner, or allow the generated runner to be used. In practice this does not remove any capability from the package user, but it may require some to change their gulpfile if they were relying on the old default behavior.